### PR TITLE
Backport some patches from upcoming RHOS 10 release

### DIFF
--- a/0001-lib-automake.mk-don-t-install-runtime-directories.patch
+++ b/0001-lib-automake.mk-don-t-install-runtime-directories.patch
@@ -1,0 +1,38 @@
+From e660cd02a3fd80fe37dfa6264b2d8f3eed1d7c08 Mon Sep 17 00:00:00 2001
+From: Aaron Conole <aconole@redhat.com>
+Date: Mon, 17 Apr 2017 13:59:50 -0400
+Subject: [PATCH 1/3] lib/automake.mk: don't install runtime directories
+
+The Open vSwitch run, log, and DB directories are installed as part of the
+normal `make install` process.  However, this means they are created with
+user and group ownership that may conflict with the desired user.  For
+example, running `make install` as root will install those files as
+root:root, whereas the runtime user desired may be openvswitch:openvswitch.
+
+Since these directories are automatically created as part of the ovs-ctl
+command, and with the correct user:group permissions, it makes sense to
+delay creation until these directories are actually required.
+
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+(cherry picked from commit d0c961a99f570ec1973bf5540ba9237b6720c848)
+---
+ lib/automake.mk | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/lib/automake.mk b/lib/automake.mk
+index e4cfc976f..1a9f1f99d 100644
+--- a/lib/automake.mk
++++ b/lib/automake.mk
+@@ -526,8 +526,5 @@ EXTRA_DIST += build-aux/extract-ofp-msgs
+ 
+ INSTALL_DATA_LOCAL += lib-install-data-local
+ lib-install-data-local:
+-	$(MKDIR_P) $(DESTDIR)$(RUNDIR)
+ 	$(MKDIR_P) $(DESTDIR)$(PKIDIR)
+-	$(MKDIR_P) $(DESTDIR)$(LOGDIR)
+-	$(MKDIR_P) $(DESTDIR)$(DBDIR)
+ 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/openvswitch
+-- 
+2.13.3
+

--- a/0001-mcast-snooping-Avoid-segfault-for-vswitchd.patch
+++ b/0001-mcast-snooping-Avoid-segfault-for-vswitchd.patch
@@ -1,0 +1,32 @@
+From 6db65e29248e0524e240681e29b1a452345105aa Mon Sep 17 00:00:00 2001
+From: nickcooper-zhangtonghao <nic@opencloud.tech>
+Date: Fri, 3 Mar 2017 01:37:21 -0800
+Subject: [PATCH] mcast-snooping: Avoid segfault for vswitchd.
+
+The ports which are attached mrouters or hosts, were destroyed
+by users via ovs-vsctl commands. Currently the vswitch will
+segfault if users use "ovs-appctl mdb/show" to show mdb info.
+This patch avoids a segfault.
+
+Signed-off-by: nickcooper-zhangtonghao <nic@opencloud.tech>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+(cherry picked from commit 0ae08f8334f9d62889031277722eccac33b404ef)
+---
+ ofproto/ofproto-dpif.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ofproto/ofproto-dpif.c b/ofproto/ofproto-dpif.c
+index 7922e5082..c7fbfa527 100644
+--- a/ofproto/ofproto-dpif.c
++++ b/ofproto/ofproto-dpif.c
+@@ -2863,6 +2863,7 @@ bundle_destroy(struct ofbundle *bundle)
+     }
+ 
+     bundle_flush_macs(bundle, true);
++    mcast_snooping_flush_bundle(ofproto->ms, bundle);
+     hmap_remove(&ofproto->bundles, &bundle->hmap_node);
+     free(bundle->name);
+     free(bundle->trunks);
+-- 
+2.13.3
+

--- a/0001-mcast-snooping-Flush-ports-mdb-when-VLAN-configurati.patch
+++ b/0001-mcast-snooping-Flush-ports-mdb-when-VLAN-configurati.patch
@@ -1,0 +1,85 @@
+From 30b5b03805b10df29a72a5e1b35a0eb088be2381 Mon Sep 17 00:00:00 2001
+From: nickcooper-zhangtonghao <nic@opencloud.tech>
+Date: Fri, 3 Mar 2017 01:37:20 -0800
+Subject: [PATCH] mcast-snooping: Flush ports mdb when VLAN configuration
+ changed.
+
+If VLAN configuration(e.g. id, mode) change occurs, the IGMP
+snooping-learned multicast groups from this port on the VLAN are
+deleted. This avoids a MCAST_ENTRY_DEFAULT_IDLE_TIME delay before
+mdb is updated again. Hardware switches (e.g. cisco) also do that.
+
+Signed-off-by: nickcooper-zhangtonghao <nic@opencloud.tech>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+(cherry picked from commit 1c4dfbc7e640f038b6739cda48a7ffeb2924ff5e)
+---
+ lib/mcast-snooping.c   | 31 +++++++++++++++++++++++++++++++
+ lib/mcast-snooping.h   |  1 +
+ ofproto/ofproto-dpif.c |  1 +
+ 3 files changed, 33 insertions(+)
+
+diff --git a/lib/mcast-snooping.c b/lib/mcast-snooping.c
+index f71321d2e..a3163f57f 100644
+--- a/lib/mcast-snooping.c
++++ b/lib/mcast-snooping.c
+@@ -942,3 +942,34 @@ mcast_snooping_wait(struct mcast_snooping *ms)
+     mcast_snooping_wait__(ms);
+     ovs_rwlock_unlock(&ms->rwlock);
+ }
++
++void
++mcast_snooping_flush_bundle(struct mcast_snooping *ms, void *port)
++{
++    struct mcast_group *g, *next_g;
++    struct mcast_mrouter_bundle *m, *next_m;
++
++    if (!mcast_snooping_enabled(ms)) {
++        return;
++    }
++
++    ovs_rwlock_wrlock(&ms->rwlock);
++    LIST_FOR_EACH_SAFE (g, next_g, group_node, &ms->group_lru) {
++        if (mcast_group_delete_bundle(ms, g, port)) {
++            ms->need_revalidate = true;
++
++            if (!mcast_group_has_bundles(g)) {
++                mcast_snooping_flush_group__(ms, g);
++            }
++        }
++    }
++
++    LIST_FOR_EACH_SAFE (m, next_m, mrouter_node, &ms->mrouter_lru) {
++        if (m->port == port) {
++            mcast_snooping_flush_mrouter(m);
++            ms->need_revalidate = true;
++        }
++    }
++
++    ovs_rwlock_unlock(&ms->rwlock);
++}
+diff --git a/lib/mcast-snooping.h b/lib/mcast-snooping.h
+index af7fb9376..f120405da 100644
+--- a/lib/mcast-snooping.h
++++ b/lib/mcast-snooping.h
+@@ -214,5 +214,6 @@ bool mcast_snooping_is_membership(ovs_be16 igmp_type);
+ /* Flush. */
+ void mcast_snooping_mdb_flush(struct mcast_snooping *ms);
+ void mcast_snooping_flush(struct mcast_snooping *ms);
++void mcast_snooping_flush_bundle(struct mcast_snooping *ms, void *port);
+ 
+ #endif /* mcast-snooping.h */
+diff --git a/ofproto/ofproto-dpif.c b/ofproto/ofproto-dpif.c
+index a86dd3f78..7922e5082 100644
+--- a/ofproto/ofproto-dpif.c
++++ b/ofproto/ofproto-dpif.c
+@@ -3048,6 +3048,7 @@ bundle_set(struct ofproto *ofproto_, void *aux,
+      * everything on this port and force flow revalidation. */
+     if (need_flush) {
+         bundle_flush_macs(bundle, false);
++        mcast_snooping_flush_bundle(ofproto->ms, bundle);
+     }
+ 
+     return 0;
+-- 
+2.13.3
+

--- a/0001-netdev-Fix-crash-when-ifa_netmask-is-null.patch
+++ b/0001-netdev-Fix-crash-when-ifa_netmask-is-null.patch
@@ -1,0 +1,32 @@
+From f70ad934920d25c5d392e18eca7d3fa1bc36c205 Mon Sep 17 00:00:00 2001
+Message-Id: <f70ad934920d25c5d392e18eca7d3fa1bc36c205.1500647421.git.tredaelli@redhat.com>
+From: Haifeng Lin <haifeng.lin@huawei.com>
+Date: Tue, 4 Jul 2017 08:52:57 +0800
+Subject: [PATCH] netdev: Fix crash when ifa_netmask is null.
+
+glibc sometimes doesn't initialize the ifa_netmask and ifa_addr fields, if
+the ioctl to fetch them fails.  Check ifa_name also just for paranoia.
+
+Signed-off-by: Haifeng Lin <haifeng.lin@huawei.com>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+---
+ lib/netdev.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/netdev.c b/lib/netdev.c
+index 26e87a2ee..0d5fad573 100644
+--- a/lib/netdev.c
++++ b/lib/netdev.c
+@@ -1967,7 +1967,8 @@ netdev_get_addrs(const char dev[], struct in6_addr **paddr,
+     for (ifa = if_addr_list; ifa; ifa = ifa->ifa_next) {
+         int family;
+ 
+-        if (strncmp(ifa->ifa_name, dev, IFNAMSIZ) || ifa->ifa_addr == NULL) {
++        if (!ifa->ifa_name || !ifa->ifa_addr || !ifa->ifa_netmask
++            || strncmp(ifa->ifa_name, dev, IFNAMSIZ)) {
+             continue;
+         }
+ 
+-- 
+2.13.3
+

--- a/0001-rhel-systemd-start-vswitchd-after-udev.patch
+++ b/0001-rhel-systemd-start-vswitchd-after-udev.patch
@@ -1,0 +1,37 @@
+From 2a951e8509fb13f7be41694c6bbb491b08c71220 Mon Sep 17 00:00:00 2001
+From: aaron conole <aconole@redhat.com>
+Date: Tue, 18 Apr 2017 11:13:49 -0400
+Subject: [PATCH] rhel-systemd: start vswitchd after udev
+
+It's possible to race with the udev service, such that dpdk ports are
+not finished being bound until after ovs-vswitchd has been started.
+This means that attempts to use the port will fail.  While it is
+possible to work around this for some NICs using port hotplug, not all
+port types are supported (for instance vfio), and it requires manual
+intervention.
+
+Fixes: 36af136b690c ("rhel-systemd: Delay shutting down the services")
+Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=1397299
+Suggested-by: Flavio Leitner <fbl@sysclose.org>
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Tested-by: Karthik Sundaravel <ksundara@redhat.com>
+Signed-off-by: Russell Bryant <russell@ovn.org>
+---
+ rhel/usr_lib_systemd_system_ovs-vswitchd.service | 2 +-
+ 1 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rhel/usr_lib_systemd_system_ovs-vswitchd.service b/rhel/usr_lib_systemd_system_ovs-vswitchd.service
+index 39627e9..22a4c63 100644
+--- a/rhel/usr_lib_systemd_system_ovs-vswitchd.service
++++ b/rhel/usr_lib_systemd_system_ovs-vswitchd.service
+@@ -1,6 +1,6 @@
+ [Unit]
+ Description=Open vSwitch Forwarding Unit
+-After=ovsdb-server.service network-pre.target
++After=ovsdb-server.service network-pre.target systemd-udev-settle.service
+ Before=network.target network.service
+ Requires=ovsdb-server.service
+ ReloadPropagatedFrom=ovsdb-server.service
+-- 
+2.9.4
+

--- a/0002-rhel-fix-the-fedora-spec.patch
+++ b/0002-rhel-fix-the-fedora-spec.patch
@@ -1,0 +1,37 @@
+From 6785bb09edf1e1b660921308b527a822420b3667 Mon Sep 17 00:00:00 2001
+From: Aaron Conole <aconole@redhat.com>
+Date: Tue, 2 May 2017 16:17:48 -0400
+Subject: [PATCH 2/3] rhel: fix the fedora spec
+
+When commit d0c961a99f57 ("lib/automake.mk: don't install
+runtime directories") landed, it broke RPM based builds since
+the requisite directories were no longer available.  This commit
+adds those directories back when making RPMs so that the package
+manager can see them.
+
+Fixes: d0c961a99f57 ("lib/automake.mk: don't install runtime directories")
+Reported-by: Lance Richardson <lrichard@redhat.com>
+Tested-by: Lance Richardson <lrichard@redhat.com>
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Signed-off-by: Russell Bryant <rbryant@redhat.com>
+(cherry picked from commit 2f4f43bfddfd159a8cfe963234530922f602ae07)
+---
+ rhel/openvswitch-fedora.spec.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/rhel/openvswitch-fedora.spec.in b/rhel/openvswitch-fedora.spec.in
+index 30587aacb..ec4de510c 100644
+--- a/rhel/openvswitch-fedora.spec.in
++++ b/rhel/openvswitch-fedora.spec.in
+@@ -195,6 +195,8 @@ make -f %{_datadir}/selinux/devel/Makefile
+ rm -rf $RPM_BUILD_ROOT
+ make install DESTDIR=$RPM_BUILD_ROOT
+ 
++install -d -m 0755 $RPM_BUILD_ROOT%{_rundir}/openvswitch
++install -d -m 0755 $RPM_BUILD_ROOT%{_localstatedir}/log/openvswitch
+ install -d -m 0755 $RPM_BUILD_ROOT%{_sysconfdir}/openvswitch
+ 
+ install -p -D -m 0644 \
+-- 
+2.13.3
+

--- a/0003-make-logs-not-readable-by-other.patch
+++ b/0003-make-logs-not-readable-by-other.patch
@@ -1,0 +1,87 @@
+From 55655f358cea2c7c79842563603fdbc19351243e Mon Sep 17 00:00:00 2001
+From: Timothy Redaelli <tredaelli@redhat.com>
+Date: Mon, 19 Jun 2017 16:50:21 +0200
+Subject: [PATCH 3/3] make logs not readable by other
+
+The Open vSwitch log directory and files are currently set world readable.
+
+However, since only Open vSwitch users and processes need to access this
+directory and these files there is no need to allow the world to access them,
+since it can result in the exposure of sensitive information.
+
+Signed-off-by: Timothy Redaelli <tredaelli@redhat.com>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+(cherry picked from commit 03736a6726cb1faf2584ad2536625471ab6d17c5)
+---
+ lib/vlog.c                      | 2 +-
+ rhel/openvswitch-fedora.spec.in | 2 +-
+ utilities/ovs-lib.in            | 5 +++--
+ utilities/ovs-pki.in            | 2 +-
+ 4 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/lib/vlog.c b/lib/vlog.c
+index 333337b10..2a60ca34a 100644
+--- a/lib/vlog.c
++++ b/lib/vlog.c
+@@ -360,7 +360,7 @@ vlog_set_log_file(const char *file_name)
+     new_log_file_name = (file_name
+                          ? xstrdup(file_name)
+                          : xasprintf("%s/%s.log", ovs_logdir(), program_name));
+-    new_log_fd = open(new_log_file_name, O_WRONLY | O_CREAT | O_APPEND, 0666);
++    new_log_fd = open(new_log_file_name, O_WRONLY | O_CREAT | O_APPEND, 0660);
+     if (new_log_fd < 0) {
+         VLOG_WARN("failed to open %s for logging: %s",
+                   new_log_file_name, ovs_strerror(errno));
+diff --git a/rhel/openvswitch-fedora.spec.in b/rhel/openvswitch-fedora.spec.in
+index ec4de510c..6ccba598e 100644
+--- a/rhel/openvswitch-fedora.spec.in
++++ b/rhel/openvswitch-fedora.spec.in
+@@ -196,7 +196,7 @@ rm -rf $RPM_BUILD_ROOT
+ make install DESTDIR=$RPM_BUILD_ROOT
+ 
+ install -d -m 0755 $RPM_BUILD_ROOT%{_rundir}/openvswitch
+-install -d -m 0755 $RPM_BUILD_ROOT%{_localstatedir}/log/openvswitch
++install -d -m 0750 $RPM_BUILD_ROOT%{_localstatedir}/log/openvswitch
+ install -d -m 0755 $RPM_BUILD_ROOT%{_sysconfdir}/openvswitch
+ 
+ install -p -D -m 0644 \
+diff --git a/utilities/ovs-lib.in b/utilities/ovs-lib.in
+index 4c0775053..94e878f32 100644
+--- a/utilities/ovs-lib.in
++++ b/utilities/ovs-lib.in
+@@ -150,8 +150,9 @@ version_geq() {
+ 
+ install_dir () {
+     DIR="$1"
++    INSTALL_MODE="${2:-755}"
+     if test ! -d "$DIR"; then
+-        install -d -m 755 -o root -g root "$DIR"
++        install -d -m "$INSTALL_MODE" -o root -g root "$DIR"
+         restorecon "$DIR" >/dev/null 2>&1
+     fi
+ }
+@@ -169,7 +170,7 @@ start_daemon () {
+     cd "$DAEMON_CWD"
+ 
+     # log file
+-    install_dir "$logdir"
++    install_dir "$logdir" "750"
+     set "$@" --log-file="$logdir/$daemon.log"
+ 
+     # pidfile and monitoring
+diff --git a/utilities/ovs-pki.in b/utilities/ovs-pki.in
+index 7a992a594..38dda2cd8 100755
+--- a/utilities/ovs-pki.in
++++ b/utilities/ovs-pki.in
+@@ -201,7 +201,7 @@ esac
+ 
+ logdir=$(dirname "$log")
+ if test ! -d "$logdir"; then
+-    mkdir -p -m755 "$logdir" 2>/dev/null || true
++    mkdir -p -m750 "$logdir" 2>/dev/null || true
+     if test ! -d "$logdir"; then
+         echo "$0: log directory $logdir does not exist and cannot be created" >&2
+         exit 1
+-- 
+2.13.3
+

--- a/openvswitch.spec
+++ b/openvswitch.spec
@@ -41,7 +41,7 @@ Version: 2.6.1
 License: ASL 2.0 and LGPLv2+ and SISSL
 
 %define snapshot .git20161206
-%define rel 10%{?snapshot}
+%define rel 10.1%{?snapshot}
 
 #define snapver 10346.git97bab959
 %define srcname openvswitch
@@ -94,6 +94,24 @@ Patch43: ovn-northd-ipam-handle-the-static-MAC-updates-by-the-user.patch
 
 # Backport rhel ifup vhost client mode support BZ 1418957
 Patch44: 0001-rhel-ifup-support-vhost-user-client-mode.patch
+
+# Backport rhel-systemd: Restart openvswitch service if a daemon crashes BZ 1468334
+Patch50: rhel-systemd-Restart-openvswitch-service-if-a-daemon-crashes.patch
+
+# Backport fix for Avoid segfault for vswitchd BZ 1472334
+Patch55: 0001-mcast-snooping-Avoid-segfault-for-vswitchd.patch
+# Backport fix for Flush ports mdb when VLAN configuration changed BZ 1472335
+Patch56: 0001-mcast-snooping-Flush-ports-mdb-when-VLAN-configurati.patch
+
+# Backport fix to make logs not readable by other BZ 1431490
+Patch57: 0001-lib-automake.mk-don-t-install-runtime-directories.patch
+Patch58: 0002-rhel-fix-the-fedora-spec.patch
+Patch59: 0003-make-logs-not-readable-by-other.patch
+
+Patch60: 0001-rhel-systemd-start-vswitchd-after-udev.patch
+
+Patch61: 0001-netdev-Fix-crash-when-ifa_netmask-is-null.patch
+Patch62: ovs-dev-v3-netdev-check-for-NULL-fields-in-netdev_get_addrs.patch
 
 BuildRequires: autoconf automake libtool
 BuildRequires: systemd-units openssl openssl-devel
@@ -222,6 +240,15 @@ Docker network plugins for OVN.
 %patch42 -p1
 %patch43 -p1
 %patch44 -p1
+%patch50 -p1
+%patch55 -p1
+%patch56 -p1
+%patch57 -p1
+%patch58 -p1
+%patch59 -p1
+%patch60 -p1
+%patch61 -p1
+%patch62 -p1
 
 %build
 %if 0%{?snapshot:1}
@@ -651,6 +678,14 @@ exit 0
 %{_unitdir}/ovn-controller-vtep.service
 
 %changelog
+* Tue Aug 01 2017 Timothy Redaelli <tredaelli@redhat.com> - 2.6.1-10.1.git20161206
+- Backport patch to fix random crashes when adding/removing interfaces (#1473735)
+- Restart openvswitch service if a daemon crashes (#1468334)
+- Avoid segfault for vswitchd (#1472334)
+- Flush ports mdb when VLAN configuration changed (#1472335)
+- Make logs not readable by other (#1431490)
+- Fix ovs-vswitchd start order (#1468751)
+
 * Thu Feb 16 2017 Aaron Conole <aconole@redhat.com> - 2.6.1-10.git20161206
 - vhostuser client mode support for ifup/ifdown (#1418957)
 

--- a/ovs-dev-v3-netdev-check-for-NULL-fields-in-netdev_get_addrs.patch
+++ b/ovs-dev-v3-netdev-check-for-NULL-fields-in-netdev_get_addrs.patch
@@ -1,0 +1,97 @@
+From patchwork Fri Jul 21 15:28:24 2017
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: [ovs-dev,v3] netdev: check for NULL fields in netdev_get_addrs
+From: Daniel Alvarez Sanchez <dalvarez@redhat.com>
+X-Patchwork-Id: 792177
+Message-Id: <1500650904-2751-1-git-send-email-dalvarez@redhat.com>
+To: dev@openvswitch.org
+Date: Fri, 21 Jul 2017 15:28:24 +0000
+
+When the interfaces list is retrieved through getiffaddrs(), there
+might be elements with iface_name set to NULL.
+
+This patch checks ifa_name to be not NULL before comparing it to the
+actual device name in the loop that calculates how many interfaces
+exist with that same name.
+
+Also, this patch checks that ifa_netmask is not NULL for coherence
+with the existing code so that it doesn't allocate more memory
+than needed if this field is NULL.
+
+Note, that these checks are already being done later in the function
+so it should be done in both places.
+
+Signed-off-by: Daniel Alvarez <dalvarez@redhat.com>
+---
+v2 -> v3: fix email formatting since v2 wasn't correctly picked by
+          patchwork.
+
+I've been debugging a coredump produced by a segmentation fault of
+ovs-vswitchd. It seems to be caused by a NULL pointer passed to
+strncmp by netdev_get_addrs() function:
+
+#0  0x00007fd840e2d34c in ?? () from /lib64/libc.so.6
+#1  0x00007fd842ae63b6 in netdev_get_addrs (dev=0x7fd844e1e750 "vlan121", paddr=paddr@entry=0x7ffe833244a0, pmask=pmask@entry=0x7ffe83324498, n_in=n_in@entry=0x7ffe83324494)
+    at lib/netdev.c:1890
+#2  0x00007fd842b70365 in netdev_linux_get_addr_list (netdev_=0x7fd844e8ec40, addr=0x7ffe833244a0, mask=0x7ffe83324498, n_cnt=0x7ffe83324494) at lib/netdev-linux.c:2517
+#3  0x00007fd842ae576f in netdev_get_addr_list (netdev=<optimized out>, addr=addr@entry=0x7ffe833244a0, mask=mask@entry=0x7ffe83324498, n_addr=n_addr@entry=0x7ffe83324494)
+    at lib/netdev.c:1133
+#4  0x00007fd842b30191 in get_src_addr (ip6_dst=ip6_dst@entry=0x7ffe8332522c, output_bridge=output_bridge@entry=0x7ffe8332524c "vlan121", psrc=psrc@entry=0x7fd844e6f0a0)
+    at lib/ovs-router.c:146
+#5  0x00007fd842b30655 in ovs_router_insert__ (priority=<optimized out>, ip6_dst=ip6_dst@entry=0x7ffe8332522c, plen=<optimized out>,
+    output_bridge=output_bridge@entry=0x7ffe8332524c "vlan121", gw=gw@entry=0x7ffe8332523c) at lib/ovs-router.c:200
+#6  0x00007fd842b30e37 in ovs_router_insert (ip_dst=ip_dst@entry=0x7ffe8332522c, plen=<optimized out>, output_bridge=output_bridge@entry=0x7ffe8332524c "vlan121",
+    gw=gw@entry=0x7ffe8332523c) at lib/ovs-router.c:228
+#7  0x00007fd842b79d24 in route_table_handle_msg (change=0x7ffe83325220) at lib/route-table.c:295
+#8  route_table_reset () at lib/route-table.c:174
+#9  0x00007fd842b79ef5 in route_table_run () at lib/route-table.c:127
+#10 0x00007fd842ae3701 in netdev_vport_run (netdev_class=<optimized out>) at lib/netdev-vport.c:319
+#11 0x00007fd842ae438e in netdev_run () at lib/netdev.c:163
+#12 0x00007fd8428f329c in main (argc=10, argv=0x7ffe833265a8) at vswitchd/ovs-vswitchd.c:114
+
+In frame 1 we can confirm this:
+
+(gdb) p *ifa
+$94 = {ifa_next = 0x7fd8451c2a78, ifa_name = 0x0, ifa_flags = 0, ifa_addr = 0x7fd8451c29f8, ifa_netmask = 0x7fd8451c2a1c, ifa_ifu = {ifu_broadaddr = 0x0, ifu_dstaddr = 0x0}, ifa_data = 0x0}
+
+(gdb) list
+1885            if (ifa->ifa_addr != NULL) {
+1886                int family;
+1887
+1888                family = ifa->ifa_addr->sa_family;
+1889                if (family == AF_INET || family == AF_INET6) {
+1890                    if (!strncmp(ifa->ifa_name, dev, IFNAMSIZ)) {
+1891                        cnt++;
+1892                    }
+1893                }
+1894            }
+
+
+Later in the code, we're checking for ifa_name [0] not NULL so it
+makes sense to check it as well where this patch does it.
+
+Also, as it's not expected to get an unnamed interface, it
+may happen and also iproute2 checks this condition when retrieving
+the interfaces list via netlink [1].
+
+[0] https://github.com/openvswitch/ovs/blob/master/lib/netdev.c#L1970
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git/tree/ip/ipaddress.c#n664
+
+ lib/netdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/netdev.c b/lib/netdev.c
+index 0d5fad5..eed4d09 100644
+--- a/lib/netdev.c
++++ b/lib/netdev.c
+@@ -1946,7 +1946,7 @@ netdev_get_addrs(const char dev[], struct in6_addr **paddr,
+     }
+ 
+     for (ifa = if_addr_list; ifa; ifa = ifa->ifa_next) {
+-        if (ifa->ifa_addr != NULL) {
++        if (ifa->ifa_addr && ifa->ifa_name && ifa->ifa_netmask) {
+             int family;
+ 
+             family = ifa->ifa_addr->sa_family;

--- a/rhel-systemd-Restart-openvswitch-service-if-a-daemon-crashes.patch
+++ b/rhel-systemd-Restart-openvswitch-service-if-a-daemon-crashes.patch
@@ -1,0 +1,99 @@
+From c19bf36d848cbdf755c6760fad1726c95e4377f1 Mon Sep 17 00:00:00 2001
+From: Eelco Chaudron <echaudro@redhat.com>
+Date: Mon, 27 Feb 2017 15:56:41 -0500
+Subject: [PATCH] rhel-systemd: Restart openvswitch service if a daemon crashes
+
+Currently if either ovsdb-server or ovs-vswitchd is crashing the
+daemon is not restarting leaving the system in faulty state.
+This patch will detect the daemon crash and will restart the
+openvswitch service.
+
+Here is a (bit to wide) table showing the behavior before and after
+the patch. Note that only the Crash behavior has changed:
+
+Before patch:
+                               |       Process Status        |             systemctl <> status            |
+                               | ovs-vswitchd | ovsdb-server | openvswitch  | ovs-vswitchd | ovsdb-server |
+                               +--------------+--------------+--------------+--------------+--------------+
+systemctl start openvswitch*   | started      | started      |active,exited |active,running|active,running|
+Crash vswitchd                 | crashed      | stopped      |inactive, dead|failed        |inactive,dead |
+Crash ovsdb                    | stopped      | crashed      |inactive, dead|inactive,dead |failed        |
+systemctl restart openvswitch  | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl restart ovs-vswitchd | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl restart ovsdb-server | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl stop openvswitch     | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl stop ovs-vswitchd    | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl stop ovsdb-server    | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl start ovs-vswitchd*  | started      | started      |inactive, dead|active,running|active,running|
+systemctl start ovsdb-server*  | not started  | started      |inactive, dead|inactive, dead|active,running|
+
+With patch:
+                               |       Process Status        |             systemctk <> status            |
+                               | ovs-vswitchd | ovsdb-server | openvswitch  | ovs-vswitchd | ovsdb-server |
+                               +--------------+--------------+--------------+--------------+--------------+
+systemctl start openvswitch*   | started      | started      |active,exited |active,running|active,running|
+Crash vswitchd                 | crash,started| re-started   |active,exited |active,running|active,running|
+Crash ovsdb                    | re-started   | crash,started|active,exited |active,running|active,running|
+systemctl restart openvswitch  | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl restart ovs-vswitchd | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl restart ovsdb-server | re-started   | re-started   |active,exited |active,running|active,running|
+systemctl stop openvswitch     | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl stop ovs-vswitchd    | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl stop ovsdb-server    | stopped      | stopped      |inactive, dead|inactive,dead |inactive,dead |
+systemctl start ovs-vswitchd*  | started      | started      |inactive, dead|active,running|active,running|
+systemctl start ovsdb-server*  | not started  | started      |inactive, dead|inactive, dead|active,running|
+
+* These commands where executed when no ovs related processes where
+  running. All other commands where executed when OVS was successfully
+  running.
+
+Signed-off-by: Eelco Chaudron <echaudro@redhat.com>
+Acked-by: Markos Chandras <mchandras@suse.de>
+Acked-by: Aaron Conole <aconole@redhat.com>
+Acked-by: Flavio Leitner <fbl@sysclose.org>
+Signed-off-by: Russell Bryant <russell@ovn.org>
+---
+ rhel/usr_lib_systemd_system_openvswitch.service  | 4 ++--
+ rhel/usr_lib_systemd_system_ovs-vswitchd.service | 1 +
+ rhel/usr_lib_systemd_system_ovsdb-server.service | 1 +
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/rhel/usr_lib_systemd_system_openvswitch.service b/rhel/usr_lib_systemd_system_openvswitch.service
+index bdbceaefbb..faca44b544 100644
+--- a/rhel/usr_lib_systemd_system_openvswitch.service
++++ b/rhel/usr_lib_systemd_system_openvswitch.service
+@@ -3,8 +3,8 @@ Description=Open vSwitch
+ Before=network.target network.service
+ After=network-pre.target ovsdb-server.service ovs-vswitchd.service
+ PartOf=network.target
+-BindsTo=ovsdb-server.service
+-BindsTo=ovs-vswitchd.service
++Requires=ovsdb-server.service
++Requires=ovs-vswitchd.service
+ 
+ [Service]
+ Type=oneshot
+diff --git a/rhel/usr_lib_systemd_system_ovs-vswitchd.service b/rhel/usr_lib_systemd_system_ovs-vswitchd.service
+index 01d9cee26b..39627e96e9 100644
+--- a/rhel/usr_lib_systemd_system_ovs-vswitchd.service
++++ b/rhel/usr_lib_systemd_system_ovs-vswitchd.service
+@@ -9,6 +9,7 @@ PartOf=openvswitch.service
+ 
+ [Service]
+ Type=forking
++Restart=on-failure
+ EnvironmentFile=-/etc/sysconfig/openvswitch
+ ExecStart=/usr/share/openvswitch/scripts/ovs-ctl \
+           --no-ovsdb-server --no-monitor --system-id=random \
+diff --git a/rhel/usr_lib_systemd_system_ovsdb-server.service b/rhel/usr_lib_systemd_system_ovsdb-server.service
+index d3d740839f..68deace7ce 100644
+--- a/rhel/usr_lib_systemd_system_ovsdb-server.service
++++ b/rhel/usr_lib_systemd_system_ovsdb-server.service
+@@ -7,6 +7,7 @@ PartOf=openvswitch.service
+ 
+ [Service]
+ Type=forking
++Restart=on-failure
+ EnvironmentFile=-/etc/sysconfig/openvswitch
+ ExecStart=/usr/share/openvswitch/scripts/ovs-ctl \
+           --no-ovs-vswitchd --no-monitor --system-id=random \


### PR DESCRIPTION
Backport patch to fix random crashes when adding/removing interfaces
Restart openvswitch service if a daemon crashes
Avoid segfault for vswitchd
Flush ports mdb when VLAN configuration changed
Make logs not readable by other
Fix ovs-vswitchd start order